### PR TITLE
Convert Harmless Log Messages to INFO (NGWPC-8287)

### DIFF
--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -1382,8 +1382,8 @@ void ueb::BmiUEB::runPointUEB(
                         bmi_ueb_ss << "Nonzero nightime incident radiation of " << Qsiobs;
                         bmi_ueb_ss << " at date " << Year << "-" << Month << "-" << Day << "T"
                                    << dHour;
-                        bmi_ueb_ss << ". Limiting log to 3 error messages." << endl;
-                        LOG(bmi_ueb_ss.str(), LogLevel::SEVERE);
+                        bmi_ueb_ss << " Possible measurement problem (i.e. moonshine). Limiting log to 3 error messages." << endl;
+                        LOG(bmi_ueb_ss.str(), LogLevel::INFO); // According to developer, this is harmless message.
                         bmi_ueb_ss.str("");
                         ++radwarnflag;
                     }

--- a/src/ueb/snowdgtv.cpp
+++ b/src/ueb/snowdgtv.cpp
@@ -2506,7 +2506,7 @@ labl17:
                                         << uebCellX << "."; // mtime[4]<<endl;
                             snowdgtv_ss << " A canopy temperature of 273 K assumed.";
                             snowdgtv_ss << " Limiting log to 3 error messages." << endl;
-                            LOG(snowdgtv_ss.str(), LogLevel::SEVERE);
+                            LOG(snowdgtv_ss.str(), LogLevel::INFO);  // According to developer, this is harmless message.
                             snowdgtv_ss.str("");
                         }
                     }


### PR DESCRIPTION
There are 2 types of log messages generated by the UEB module that, according to the developer, are informative and harmless. When the EWTS logger was added to the module, these were classified as SEVERE and should be set to the log level of INFO instead. 

## Changes

- Change log level to INFO from SEVERE.
- Added more information to one of the log messages based on comments located in the code.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

