### PR TITLE
Adapt serialization to revised protocol

### DIFF
--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -341,6 +341,8 @@ int ueb::BmiUEB::GetVarGrid(std::string name) {
 std::string ueb::BmiUEB::GetVarType(std::string name) {
     if (name.compare("serialization_create") == 0) {
         return "uint64_t";
+    } else if (name.compare("serialization_size") == 0) {
+        return "uint64_t";
     } else if (name.compare("serialization_state") == 0) {
         return "char";
     } else if (name.compare("serialization_free") == 0) {
@@ -398,6 +400,8 @@ std::string ueb::BmiUEB::GetVarType(std::string name) {
 
 int ueb::BmiUEB::GetVarItemsize(std::string name) {
     if (name.compare("serialization_create") == 0) {
+        return sizeof(uint64_t);
+    } else if (name.compare("serialization_size") == 0) {
         return sizeof(uint64_t);
     } else if (name.compare("serialization_state") == 0) {
         return sizeof(char);
@@ -477,6 +481,8 @@ std::string ueb::BmiUEB::GetVarUnits(std::string name) {
 
 int ueb::BmiUEB::GetVarNbytes(std::string name) {
     if (name.compare("serialization_create") == 0) {
+        return sizeof(uint64_t);
+    } else if (name.compare("serialization_size") == 0) {
         return sizeof(uint64_t);
     } else if (name.compare("serialization_state") == 0) {
         return this->m_serialized_length;
@@ -650,8 +656,7 @@ void ueb::BmiUEB::GetValue(std::string name, void* dest) {
 
 void* ueb::BmiUEB::GetValuePtr(std::string name) {
     // special cases for serialization
-    if (name.compare("serialization_create") == 0) {
-        this->new_serialized();
+    if (name.compare("serialization_size") == 0) {
         return (void*)&this->m_serialized_length;
     } else if (name.compare("serialization_state") == 0) {
         return (void*)this->m_serialized.data();
@@ -781,9 +786,8 @@ void ueb::BmiUEB::SetValue(std::string name, void* src) {
         this->clear_serialized();
         return;
     } else if (name.compare("serialization_create") == 0) {
-        auto msg = "Cannot set value with \"serialization_create\".";
-        // Logger::Log(LogLevel::WARNING, msg);
-        throw std::invalid_argument(msg);
+        this->new_serialized();
+        return;
     }
     void* dest = NULL;
 


### PR DESCRIPTION
The earlier BMI state saving protocol was not going to be tenable on Fortran due to intent(in) dummy arguments. This revision simplifies the protocol such that SetValue is used for mutating actions, and GetValue/GetValuePtr are used for queries.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: