### PR TITLE
Added a new parameter to specify windspeed nominal measurement heights

### DIFF
--- a/examples/TWDEF_onecell/param.dat
+++ b/examples/TWDEF_onecell/param.dat
@@ -63,3 +63,5 @@ a: A in Bristow-Campbell formula for atmospheric transmittance
 0.8      
 c: C in Bristow-Campbell formula for atmospheric transmittance
 2.4 
+Zw: Nominal meas. heights for windspeed (2m)
+2 

--- a/src/bmi/Parameters.cxx
+++ b/src/bmi/Parameters.cxx
@@ -58,7 +58,10 @@ std::array<float, NPARS> ueb::Parameters::getParams() const {
     Param[18] = -9999;
     Param[19] = -9999;
     Param[20] = _parArray[19];
-    for (int i = 22; i < 32; i++) Param[i] = _parArray[i - 2];
+    for (int i = 22; i < NPARS - 1; i++) Param[i] = _parArray[i - 2];
+
+    //set the Zw, nominal height of windspeed
+    Param[32] = _parArray[32];
 
     return Param;
 }
@@ -102,6 +105,7 @@ rimax:  Maximum value of Richardson number for stability correction
 wcoeff: Wind decay coefficient for the forest
 a: A in Bristow-Campbell formula for atmospheric transmittance
 c: C in Bristow-Campbell formula for atmospheric transmittance
+Zw: Nominal meas. heights for windspeed, default to 2 m
 *
 */
 const std::array<std::string, NPARS> ueb::Parameters::parameter_names{
@@ -139,6 +143,7 @@ const std::array<std::string, NPARS> ueb::Parameters::parameter_names{
     "wcoeff", // Wind decay coefficient for the forest
     "a", // A in Bristow-Campbell formula for atmospheric transmittance
     "c", // C in Bristow-Campbell formula for atmospheric transmittance
+    "Zw", //Nominal meas. heights for windspeed, defaults to 2 m
 };
 
 const std::map<std::string, std::string> ueb::Parameters::parameter_units{
@@ -177,7 +182,8 @@ const std::map<std::string, std::string> ueb::Parameters::parameter_units{
     {"rimax",             "1"                }, //  Maximum value of Richardson number for stability correction
     {"wcoeff",            "1"                }, // Wind decay coefficient for the forest
     {"a",                 "1"                }, // A in Bristow-Campbell formula for atmospheric transmittance
-    {"c",                 "1"                }  // C in Bristow-Campbell formula for atmospheric transmittance
+    {"c",                 "1"                },  // C in Bristow-Campbell formula for atmospheric transmittance
+    {"Zw",                "m"                } // Nominal meas. heights for windspeed, defaults to 2 m
 };
 
 std::ostream& operator<<(std::ostream& os, ueb::Parameters p) { // operator<<

--- a/src/bmi/Parameters.hxx
+++ b/src/bmi/Parameters.hxx
@@ -5,7 +5,7 @@
 #include <map>
 #include <string>
 
-#define NPARS 32
+#define NPARS 33
 
 namespace ueb {
 class Parameters;

--- a/src/ueb/canopy.cpp
+++ b/src/ueb/canopy.cpp
@@ -310,11 +310,15 @@ void AeroRes(
                            // corrections
         Wcoeff = param[31], //
 
+	//new parameter added for windspeed
+        Zw = param[32], // Nominal meas. height for wind speed
+
         Cc   = sitev[4], // Canopy Cover
         Hcan = sitev[5], // Canopy height
         LAI  = sitev[6]; // Leaf Area Index
 
-    Zm  = Hcan + z; // observed wind speed above the canopy
+    //Zm  = Hcan + z; // observed wind speed above the canopy
+    Zm  = Hcan + Zw; // observed wind speed above the canopy
     LAI = Cc * LAI;
     if (V <= 0) {
         Ra     = 0.0;
@@ -332,8 +336,16 @@ void AeroRes(
         if (LAI == 0) // For open area
         {
             Vz  = V;
-            Rbc = (1.0 / (pow(K_vc, 2) * Vz) * pow((log(z / zo)), 2.0)) * 1 /
+            //Rbc = (1.0 / (pow(K_vc, 2) * Vz) * pow((log(z / zo)), 2.0)) * 1 /
+	    //we use windspeed height (Zw) instead of temperature height (z) here
+            Rbc = (1.0 / (pow(K_vc, 2) * Vz) * pow((log(Zw / zo)), 2.0)) * 1 /
                   Hs_f; // sub layer snow resistance; Hs_f: to convert resistance second to hour
+	    //this is the eq. 29 in 
+	    //Mahat, V., D. G. Tarboton, and N. P. Molotch (2013), 
+	    //Testing above- and below-canopy representations of turbulent 
+	    //fluxes in an energy balance snowmelt model, 
+	    //Water Resour. Res., 49, doi:10.1002/wrcr.20073.
+	    //z is Nominal meas. height for air temp. and humidity [2m], 
             Ri = Gra_v * (Ta - Tss) * z / (pow(Vz, 2.0) * (0.5 * (Ta + Tss) + 273.15));
             if (Ri > Rimax)
                 Ri = Rimax;
@@ -357,9 +369,13 @@ void AeroRes(
                  1 / Hs_f; // Increased ten times (Calder 1990, Lundberg and Halldin 1994)
             //        Below canopy aerodynamic resistance
             Rc = (Hcan * exp(ndecay) / (Kh * ndecay) *
-                  (exp(-ndecay * z / Hcan) - exp(-ndecay * (d + Z0c) / Hcan))) *
+                  //(exp(-ndecay * z / Hcan) - exp(-ndecay * (d + Z0c) / Hcan))) *
+		  //should use windspeed height, Zw
+                  (exp(-ndecay * Zw / Hcan) - exp(-ndecay * (d + Z0c) / Hcan))) *
                  1 / Hs_f;
-            Rs = (1.0 / (pow(K_vc, 2) * Vz) * pow((log(z / zo)), 2.0)) * 1 / Hs_f;
+            //Rs = (1.0 / (pow(K_vc, 2) * Vz) * pow((log(z / zo)), 2.0)) * 1 / Hs_f;
+  	    //should use windspeed height, Zw
+            Rs = (1.0 / (pow(K_vc, 2) * Vz) * pow((log(Zw / zo)), 2.0)) * 1 / Hs_f;
             Rc = Rc + Rs; // Total below canopy resistance
             //        Bulk aerodynamic resistance (used when there is no snow in the canopy)
             Rbc = Rc + Ra; // Total aerodynamic resistance from ground to above canopy used when
@@ -371,6 +387,13 @@ void AeroRes(
             Rl     = 1 / (LAI * Lbmean) * 1 / Hs_f;
             //        Leaf boundary layer conductance: reciprocal of resistance
             RKINl = 1.0 / Rl;
+
+	    //this is the eq. 29 in 
+	    //Mahat, V., D. G. Tarboton, and N. P. Molotch (2013), 
+	    //Testing above- and below-canopy representations of turbulent 
+	    //fluxes in an energy balance snowmelt model, 
+	    //Water Resour. Res., 49, doi:10.1002/wrcr.20073.
+	    //z is Nominal meas. height for air temp. and humidity [2m], 
             //      Correction for Ra, Rc and Rac for stable and unstable condition
             Ri = Gra_v * (Ta - Tss) * z /
                  (pow(Vz, 2.0) * (0.5 * (Ta + Tss) + 273.15)
@@ -422,7 +445,10 @@ void WINDTRANab(
     float &Vc
 ) // Out put wind speed within canopy at height 2 m
 {
-    float Z    = param[4], //  Nominal meas. height for air temp. and humidity [2m],
+    //float Z    = param[4], //  Nominal meas. height for air temp. and humidity [2m],
+    //
+                             //Now we use the new parameter Zw, which is param[32], for windspeed height, 
+    float Z    = param[32], //  Nominal meas. height for windspeed [2m], 
         Wcoeff = param[31], //
 
         Cc    = sitev[4], // Canopy Cover

--- a/src/ueb/canopy.cpp
+++ b/src/ueb/canopy.cpp
@@ -448,7 +448,7 @@ void WINDTRANab(
     //float Z    = param[4], //  Nominal meas. height for air temp. and humidity [2m],
     //
                              //Now we use the new parameter Zw, which is param[32], for windspeed height, 
-    float Z    = param[32], //  Nominal meas. height for windspeed [2m], 
+    float Z    = param[32], //  Nominal meas. height for windspeed 
         Wcoeff = param[31], //
 
         Cc    = sitev[4], // Canopy Cover


### PR DESCRIPTION
A new parameter, Zw, is added to the parameter file to specify windspeed nominal measurement heights, separating it from the z parameter, the nominal meas. heights for air temp. and humidity.
## Additions

-None

## Removals

-None

## Changes

-   modified:   examples/TWDEF_onecell/param.dat
        modified:   src/bmi/Parameters.cxx
        modified:   src/bmi/Parameters.hxx
        modified:   src/ueb/canopy.cpp

## Testing

1. passed

## Screenshots(ngen_python_3_10_14) [Zhengtao.Cui@coastalnonlegacy-3 TWDEF_onecell]$ diff Point00.txt Point00.txt.bench_mark 
(ngen_python_3_10_14) [Zhengtao.Cui@coastalnonlegacy-3 TWDEF_onecell]$ 


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
