### PR TITLE
Make time step calculation inclusive on end time (NGWPC-9036)

### DIFF
--- a/src/bmi/ControlFile.cxx
+++ b/src/bmi/ControlFile.cxx
@@ -251,7 +251,7 @@ int ueb::ControlFile::getModelTotalTimeSteps() const {
     // model time steps
     int numTotalTs = (int)ceil(modelSpan * (24 / modelDT));
 
-    return numTotalTs;
+    return numTotalTs + 1; // add one to account for the end time being included in the calculations
 }
 
 int ueb::ControlFile::getInpDailyorSubdaily() {


### PR DESCRIPTION
UEB stores its results in vectors that have their size determined on initialization. The formula for calculating the space needed for all time steps did not include the last time step (exclusive end time). NGEN will run the end time step (inclusive end time), and this would cause UEB to start writing results to unallocated memory.


## Changes

- Function for determining the number of time steps that will be run adds 1 to account for the final time step.

## Testing

1. Runs using UEB on AWS WorkSpaces using RTE Docker containers.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
