### PR TITLE
Add GetLogLevel method to Logger source file

### DIFF
--- a/src/utilities/Logger.cpp
+++ b/src/utilities/Logger.cpp
@@ -418,3 +418,7 @@ std::string Logger::CreateTimestamp(bool appendMS, bool iso) {
 std::string Logger::GetLogFilePath() {
     return logFilePath;
 }
+
+LogLevel Logger::GetLogLevel(void) {
+    return logLevel;
+} 


### PR DESCRIPTION
The GetLogLevel method was declared in the Logger.hpp file but not defined in the Logger.cpp file.

## Additions

- Added GetLogLevel method definition in Logger source file

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
