### PR TITLE
Compile-time Output Suppression and Reset Time Message (NGWPC-9628)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project (bmi-ueb-cxx CXX)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fPIC")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-option(UEB_SUPRESS_OUTPUTS "Build where UEB BMI's Finalize() will not create outputs" OFF)
+option(UEB_SUPPRESS_OUTPUTS "Build where UEB BMI's Finalize() will not create outputs" OFF)
 
 # -----------------------------------------------------------------------------
 # Find the Boost library and configure usage
@@ -36,9 +36,9 @@ else()
 
 endif()
 
-if(UEB_SUPRESS_OUTPUTS)
+if(UEB_SUPPRESS_OUTPUTS)
     message("-- UEB compiled to not create its own outputs")
-    add_compile_definitions(UEB_SUPRESS_OUTPUTS)
+    add_compile_definitions(UEB_SUPPRESS_OUTPUTS)
 endif()
 
 link_libraries(Boost::serialization)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ else()
 
 endif()
 
+if(UEB_SUPRESS_OUTPUTS)
+    message("-- UEB compiled to not create its own outputs")
+    add_compile_definitions(UEB_SUPRESS_OUTPUTS)
+endif()
+
 link_libraries(Boost::serialization)
 
 add_subdirectory (src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project (bmi-ueb-cxx CXX)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fPIC")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+option(UEB_SUPRESS_OUTPUTS "Build where UEB BMI's Finalize() will not create outputs" OFF)
+
 # -----------------------------------------------------------------------------
 # Find the Boost library and configure usage
 set(Boost_USE_STATIC_LIBS OFF)

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -106,7 +106,7 @@ void ueb::BmiUEB::Initialize(std::string config_file) {
 
             _outvarArray[cell].resize(numOut);
             for (auto& v : _outvarArray[cell]) {
-                #ifdef UEB_SUPRESS_OUTPUTS
+                #ifdef UEB_SUPPRESS_OUTPUTS
                 // only need one space when not recording all results
                 v.resize(1);
                 #else
@@ -143,8 +143,8 @@ void ueb::BmiUEB::Update() {
     float Inpt[niv];
 
     int istep = this->get_istep();
-#ifdef UEB_SUPRESS_OUTPUTS
-    // when supressing outputs, outputs will be updated in plcae in the 1 sized output arrays
+#ifdef UEB_SUPPRESS_OUTPUTS
+    // when suppressing outputs, outputs will be updated in plcae in the 1 sized output arrays
     int ostep = 0;
 #else
     // otherwise, outputs will go into the same index as the inputs step
@@ -307,7 +307,7 @@ void ueb::BmiUEB::UpdateUntil(double t) // t unit is in seconds since the start 
 }
 
 void ueb::BmiUEB::Finalize() {
-#ifndef UEB_SUPRESS_OUTPUTS
+#ifndef UEB_SUPPRESS_OUTPUTS
     //
     // Point outputs
     //
@@ -758,7 +758,7 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
     );
     if (it_out != ueb::OutControl::output_var_names.end()) {
         int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
-#ifdef UEB_SUPRESS_OUTPUTS
+#ifdef UEB_SUPPRESS_OUTPUTS
         // value will always be the first when not recording previous results
         int ostep = 0;
 #else
@@ -1535,7 +1535,7 @@ void ueb::BmiUEB::updatOutVars(
     }
 }
 
-#ifndef UEB_SUPRESS_OUTPUTS
+#ifndef UEB_SUPPRESS_OUTPUTS
 void ueb::BmiUEB::outputAggregratedFiles() {
     auto activeCells = _ws.getActiveCells(_sitevars.getSiteVars().data());
 
@@ -1831,7 +1831,7 @@ void ueb::BmiUEB::outputPointFiles() {
         }
     }
 }
-#endif // not UEB_SUPRESS_OUTPUTS
+#endif // not UEB_SUPPRESS_OUTPUTS
 
 //
 // Get the UEB start time, this is different form the GetStartTime API.

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -1887,8 +1887,12 @@ void ueb::BmiUEB::serialize(Archive& ar, const unsigned int version) {
     ar & this->_cumEg;
 }
 
-void ueb::BmiUEB::load_serialized(const char* data) {
-    std::stringstream stream(data);
+void ueb::BmiUEB::load_serialized(char* data) {
+    // get size from header of data
+    uint64_t size;
+    memcpy(&size, data, sizeof(uint64_t));
+    // create stream from data after the header
+    membuf stream(data + sizeof(uint64_t), size);
     boost::archive::binary_iarchive archive(stream);
     try {
         archive >> (*this);
@@ -1906,11 +1910,15 @@ void ueb::BmiUEB::clear_serialized() {
 }
 
 void ueb::BmiUEB::new_serialized() {
-    this->m_serialized.clear();
+    // resize with room for a size of data header
+    this->m_serialized.resize(sizeof(uint64_t));
     boost::archive::binary_oarchive archive(this->m_serialized);
     try {
         archive << (*this);
         this->m_serialized_length = this->m_serialized.size();
+        // copy size of serialized data into the header
+        uint64_t serialized_size = this->m_serialized_length - sizeof(uint64_t);
+        memcpy(this->m_serialized.data(), &serialized_size, sizeof(uint64_t));
     } catch (const std::exception &e) {
         // Logger::Log(LogLevel::SEVERE, "Serializing UEB encountered an error: %s", e.what());
         this->m_serialized_length = 0;

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -13,6 +13,14 @@
 #include <boost/serialization/array.hpp>
 #include <boost/serialization/vector.hpp>
 
+namespace {
+    const auto SERIALIZATION_CREATE = "serialization_create";
+    const auto SERIALIZATION_SIZE = "serialization_size";
+    const auto SERIALIZATION_STATE = "serialization_state";
+    const auto SERIALIZATION_FREE = "serialization_free";
+    const auto RESET_TIME = "reset_time";
+}
+
 std::stringstream bmi_ueb_ss("");
 
 void ueb::BmiUEB::Initialize(std::string config_file) {
@@ -351,15 +359,15 @@ int ueb::BmiUEB::GetVarGrid(std::string name) {
 }
 
 std::string ueb::BmiUEB::GetVarType(std::string name) {
-    if (name.compare("serialization_create") == 0) {
+    if (name.compare(SERIALIZATION_CREATE) == 0) {
         return "uint64_t";
-    } else if (name.compare("serialization_size") == 0) {
+    } else if (name.compare(SERIALIZATION_SIZE) == 0) {
         return "uint64_t";
-    } else if (name.compare("serialization_state") == 0) {
+    } else if (name.compare(SERIALIZATION_STATE) == 0) {
         return "char";
-    } else if (name.compare("serialization_free") == 0) {
+    } else if (name.compare(SERIALIZATION_FREE) == 0) {
         return "int";
-    } else if (name.compare("reset_time") == 0) {
+    } else if (name.compare(RESET_TIME) == 0) {
         return "double";
     }
 
@@ -413,15 +421,15 @@ std::string ueb::BmiUEB::GetVarType(std::string name) {
 }
 
 int ueb::BmiUEB::GetVarItemsize(std::string name) {
-    if (name.compare("serialization_create") == 0) {
+    if (name.compare(SERIALIZATION_CREATE) == 0) {
         return sizeof(uint64_t);
-    } else if (name.compare("serialization_size") == 0) {
+    } else if (name.compare(SERIALIZATION_SIZE) == 0) {
         return sizeof(uint64_t);
-    } else if (name.compare("serialization_state") == 0) {
+    } else if (name.compare(SERIALIZATION_STATE) == 0) {
         return sizeof(char);
-    } else if (name.compare("serialization_free") == 0) {
+    } else if (name.compare(SERIALIZATION_FREE) == 0) {
         return sizeof(int);
-    } else if (name.compare("reset_time") == 0) {
+    } else if (name.compare(RESET_TIME) == 0) {
         return sizeof(double);
     }
 
@@ -496,15 +504,15 @@ std::string ueb::BmiUEB::GetVarUnits(std::string name) {
 }
 
 int ueb::BmiUEB::GetVarNbytes(std::string name) {
-    if (name.compare("serialization_create") == 0) {
+    if (name.compare(SERIALIZATION_CREATE) == 0) {
         return sizeof(uint64_t);
-    } else if (name.compare("serialization_size") == 0) {
+    } else if (name.compare(SERIALIZATION_SIZE) == 0) {
         return sizeof(uint64_t);
-    } else if (name.compare("serialization_state") == 0) {
+    } else if (name.compare(SERIALIZATION_STATE) == 0) {
         return this->m_serialized_length;
-    } else if (name.compare("serialization_free") == 0) {
+    } else if (name.compare(SERIALIZATION_FREE) == 0) {
         return sizeof(int);
-    } else if (name.compare("reset_time") == 0) {
+    } else if (name.compare(RESET_TIME) == 0) {
         return sizeof(double);
     }
 
@@ -664,7 +672,7 @@ void ueb::BmiUEB::GetValue(std::string name, void* dest) {
 
     src = this->GetValuePtr(name);
 
-    if (name.compare("serialiation_state") == 0) {
+    if (name.compare(SERIALIZATION_STATE) == 0) {
         std::memcpy(dest, src, this->m_serialized_length);
     } else {
         nbytes = this->GetVarNbytes(name);
@@ -674,9 +682,9 @@ void ueb::BmiUEB::GetValue(std::string name, void* dest) {
 
 void* ueb::BmiUEB::GetValuePtr(std::string name) {
     // special cases for serialization
-    if (name.compare("serialization_size") == 0) {
+    if (name.compare(SERIALIZATION_SIZE) == 0) {
         return (void*)&this->m_serialized_length;
-    } else if (name.compare("serialization_state") == 0) {
+    } else if (name.compare(SERIALIZATION_STATE) == 0) {
         return (void*)this->m_serialized.data();
     }
 
@@ -794,16 +802,16 @@ void ueb::BmiUEB::GetValueAtIndices(std::string name, void* dest, int* inds, int
 
 void ueb::BmiUEB::SetValue(std::string name, void* src) {
     // special cases for serialized state
-    if (name.compare("serialization_state") == 0) {
+    if (name.compare(SERIALIZATION_STATE) == 0) {
         this->load_serialized((char*)src);
         return;
-    } else if (name.compare("serialization_free") == 0) {
+    } else if (name.compare(SERIALIZATION_FREE) == 0) {
         this->clear_serialized();
         return;
-    } else if (name.compare("serialization_create") == 0) {
+    } else if (name.compare(SERIALIZATION_CREATE) == 0) {
         this->new_serialized();
         return;
-    } else if (name.compare("reset_time") == 0) {
+    } else if (name.compare(RESET_TIME) == 0) {
         this->reset_time();
         return;
     }

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -106,7 +106,12 @@ void ueb::BmiUEB::Initialize(std::string config_file) {
 
             _outvarArray[cell].resize(numOut);
             for (auto& v : _outvarArray[cell]) {
+                #ifdef UEB_SUPRESS_OUTPUTS
+                // only need one space when not recording all results
+                v.resize(1);
+                #else
                 v.resize(numTotalTs);
+                #endif
             }
         }
     }
@@ -137,9 +142,14 @@ void ueb::BmiUEB::Update() {
 
     float Inpt[niv];
 
-    int istep = std::round(
-        (_currentModelDateTime - this->getUEBStartTime()) * 24 * 3600 / this->GetTimeStep()
-    );
+    int istep = this->get_istep();
+#ifdef UEB_SUPRESS_OUTPUTS
+    // when supressing outputs, outputs will be updated in plcae in the 1 sized output arrays
+    int ostep = 0;
+#else
+    // otherwise, outputs will go into the same index as the inputs step
+    int ostep = istep;
+#endif
 
     auto tsvarArray  = _forcings.getTsvarArray();
     auto forcingtype = _forcings.getStrinpforcArray();
@@ -249,7 +259,7 @@ void ueb::BmiUEB::Update() {
             ); // array of 53 elements, output
             this->updatOutVars(
                 cell, // input
-                istep, // input
+                ostep, // input
                 Year, // input
                 Month, // input
                 Day, // input
@@ -266,7 +276,7 @@ void ueb::BmiUEB::Update() {
         {
             errMB = 0.0;
             for (int i = 0; i < 53; i++) OutArr[i] = 0.0;
-            for (int i = 0; i < 70; i++) _outvarArray[cell][i][istep] = 0.0;
+            for (int i = 0; i < 70; i++) _outvarArray[cell][i][ostep] = 0.0;
         }
     }
 
@@ -277,7 +287,7 @@ void ueb::BmiUEB::Update() {
 void ueb::BmiUEB::UpdateUntil(double t) // t unit is in seconds since the start time
 {
     // convert days to seconds
-    double time = (_currentModelDateTime - this->getUEBStartTime()) * 24 * 3600;
+    double time = this->GetCurrentTime();
 
     double dt = this->GetTimeStep();
 
@@ -297,6 +307,7 @@ void ueb::BmiUEB::UpdateUntil(double t) // t unit is in seconds since the start 
 }
 
 void ueb::BmiUEB::Finalize() {
+#ifndef UEB_SUPRESS_OUTPUTS
     //
     // Point outputs
     //
@@ -309,6 +320,7 @@ void ueb::BmiUEB::Finalize() {
     // NetCDF outputs
     //
     this->outputNcFiles();
+#endif
 
     // clean serialization
     this->clear_serialized();
@@ -699,11 +711,7 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
         int i = std::distance(ueb::ForcingVariables::forcing_var_names.begin(), it_forc);
         // SCTV and SVTV inputs
         if (strinpArray[i].infType == 0 || strinpArray[i].infType == 1) {
-            int istep = std::round(
-                            (_currentModelDateTime - this->getUEBStartTime()) * 24 * 3600 /
-                            this->GetTimeStep()
-                        ) -
-                        1;
+            int istep = this->get_istep() - 1;
 
             // Only set the value for the first cell
             // NGen wouldn't pass gradded values, only one value at a time
@@ -744,15 +752,16 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
     );
     if (it_out != ueb::OutControl::output_var_names.end()) {
         int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
-        int istep =
-            std::round(
-                (_currentModelDateTime - this->getUEBStartTime()) * 24 * 3600 / this->GetTimeStep()
-            ) -
-            1;
+#ifdef UEB_SUPRESS_OUTPUTS
+        // value will always be the first when not recording previous results
+        int ostep = 0;
+#else
+        int ostep = this->get_istep() - 1;
+#endif
         // need to check for gridded model
         // this only return the first grid cell's value
         // How about other grid cells?
-        return (void*)&_outvarArray[0][i][istep];
+        return (void*)&_outvarArray[0][i][ostep];
     }
     return (void*)NULL;
 }
@@ -913,7 +922,7 @@ double ueb::BmiUEB::GetEndTime() {
 
 double ueb::BmiUEB::GetCurrentTime() {
 
-    return (_currentModelDateTime - this->getUEBStartTime()) * 24 * 3600;
+    return (_currentModelDateTime - this->getUEBStartTime()) * (24 * 3600);
     // convert days to seconds;
 }
 
@@ -1834,6 +1843,10 @@ double ueb::BmiUEB::getUEBEndTime() {
     double dHour      = _confile.getModelEndHour();
     double EJD        = julian(ModelEndDate[0], ModelEndDate[1], ModelEndDate[2], dHour);
     return EJD;
+}
+
+int ueb::BmiUEB::get_istep() {
+    return std::round(this->GetCurrentTime() / this->GetTimeStep());
 }
 
 template<class Archive>

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -359,6 +359,8 @@ std::string ueb::BmiUEB::GetVarType(std::string name) {
         return "char";
     } else if (name.compare("serialization_free") == 0) {
         return "int";
+    } else if (name.compare("reset_time") == 0) {
+        return "double";
     }
 
     auto it_site = std::find(
@@ -419,6 +421,8 @@ int ueb::BmiUEB::GetVarItemsize(std::string name) {
         return sizeof(char);
     } else if (name.compare("serialization_free") == 0) {
         return sizeof(int);
+    } else if (name.compare("reset_time") == 0) {
+        return sizeof(double);
     }
 
     auto it_site = std::find(
@@ -500,6 +504,8 @@ int ueb::BmiUEB::GetVarNbytes(std::string name) {
         return this->m_serialized_length;
     } else if (name.compare("serialization_free") == 0) {
         return sizeof(int);
+    } else if (name.compare("reset_time") == 0) {
+        return sizeof(double);
     }
 
     int itemsize;
@@ -796,6 +802,9 @@ void ueb::BmiUEB::SetValue(std::string name, void* src) {
         return;
     } else if (name.compare("serialization_create") == 0) {
         this->new_serialized();
+        return;
+    } else if (name.compare("reset_time") == 0) {
+        this->reset_time();
         return;
     }
     void* dest = NULL;
@@ -1847,6 +1856,12 @@ double ueb::BmiUEB::getUEBEndTime() {
 
 int ueb::BmiUEB::get_istep() {
     return std::round(this->GetCurrentTime() / this->GetTimeStep());
+}
+
+void ueb::BmiUEB::reset_time() {
+    // set curernt time to what was specified in the config
+    _currentModelDateTime = this->getUEBStartTime();
+    // indexing into values seems to derive from _currentModelDateTime, so this should be the only thing that needs to be reset
 }
 
 template<class Archive>

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -1535,6 +1535,7 @@ void ueb::BmiUEB::updatOutVars(
     }
 }
 
+#ifndef UEB_SUPRESS_OUTPUTS
 void ueb::BmiUEB::outputAggregratedFiles() {
     auto activeCells = _ws.getActiveCells(_sitevars.getSiteVars().data());
 
@@ -1830,6 +1831,7 @@ void ueb::BmiUEB::outputPointFiles() {
         }
     }
 }
+#endif // not UEB_SUPRESS_OUTPUTS
 
 //
 // Get the UEB start time, this is different form the GetStartTime API.

--- a/src/bmi/bmi_ueb.hxx
+++ b/src/bmi/bmi_ueb.hxx
@@ -129,7 +129,7 @@ class BmiUEB : public bmi::Bmi {
     void serialize(Archive& ar, const unsigned int version);
     vecbuf<char> m_serialized;
     uint64_t m_serialized_length; // needs stable location for GetValuePtr
-    void load_serialized(const char* data);
+    void load_serialized(char* data);
     void clear_serialized();
     void new_serialized();
 

--- a/src/bmi/bmi_ueb.hxx
+++ b/src/bmi/bmi_ueb.hxx
@@ -223,9 +223,11 @@ class BmiUEB : public bmi::Bmi {
         float const* OutArr
     ); // array of 53 elements,  input
        //
+#ifndef UEB_SUPRESS_OUTPUTS
     void outputAggregratedFiles();
     void outputNcFiles();
     void outputPointFiles();
+#endif
     //
     // Get the UEB start time, this is different form the GetStartTime API.
     // The NextGen frameword require the GetStartTime returns 0.

--- a/src/bmi/bmi_ueb.hxx
+++ b/src/bmi/bmi_ueb.hxx
@@ -223,7 +223,7 @@ class BmiUEB : public bmi::Bmi {
         float const* OutArr
     ); // array of 53 elements,  input
        //
-#ifndef UEB_SUPRESS_OUTPUTS
+#ifndef UEB_SUPPRESS_OUTPUTS
     void outputAggregratedFiles();
     void outputNcFiles();
     void outputPointFiles();

--- a/src/bmi/bmi_ueb.hxx
+++ b/src/bmi/bmi_ueb.hxx
@@ -237,6 +237,8 @@ class BmiUEB : public bmi::Bmi {
     std::array<float, nsv> getSitevForCell(int const& cell);
 
     std::array<float, NSITEVARS> getSiteState(int const& cell);
+
+    int get_istep();
 };
 
 }; // namespace ueb

--- a/src/bmi/bmi_ueb.hxx
+++ b/src/bmi/bmi_ueb.hxx
@@ -239,6 +239,8 @@ class BmiUEB : public bmi::Bmi {
     std::array<float, NSITEVARS> getSiteState(int const& cell);
 
     int get_istep();
+
+    void reset_time();
 };
 
 }; // namespace ueb

--- a/src/bmi/bmi_ueb.hxx
+++ b/src/bmi/bmi_ueb.hxx
@@ -238,8 +238,13 @@ class BmiUEB : public bmi::Bmi {
 
     std::array<float, NSITEVARS> getSiteState(int const& cell);
 
+    // Calculate the index of where loaded data should come from and where results should be saved to based on the current time of the model.
     int get_istep();
 
+    /**
+     * Set all time properties back to the original time after Initialize has been called.
+     * This is primarily used for resetting valid indexes after loading a hot start state.
+     */
     void reset_time();
 };
 

--- a/src/bmi/vecbuf.hpp
+++ b/src/bmi/vecbuf.hpp
@@ -28,6 +28,9 @@ public:
     // Forwarder for std::vector::clear()
     constexpr void clear() { vector_.clear(); }
 
+    // Forwarder for std::vector::resize(size)
+    constexpr void resize(size_type size) { vector_.resize(size); }
+
     // Forwarder for std::vector::reserve
     constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
 
@@ -35,7 +38,7 @@ public:
     constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
 
     // Forwarder for std::vector::data
-    constexpr const value_type* data() const { return vector_.data(); }
+    constexpr value_type* data() { return vector_.data(); }
 
     // Forwarder for std::vector::size
     constexpr size_type size() const { return vector_.size(); }
@@ -110,6 +113,13 @@ private:
         return written;
     }
 
+};
+
+class membuf : public std::streambuf {
+public:
+    membuf(char *begin, size_t size) {
+        this->setg(begin, begin, begin + size);
+    }
 };
 
 #endif

--- a/src/ueb/uebdecls.cpp
+++ b/src/ueb/uebdecls.cpp
@@ -1,33 +1,33 @@
 #include "uebpgdecls.h"
 
 // js  Constant  float set
-float T_0 = 0.0; // Temperature of freezing (0 C)
-float T_k = 273.15; // Temperature to convert C to K (273.15)
-float SB_c =
+const float T_0 = 0.0; // Temperature of freezing (0 C)
+const float T_k = 273.15; // Temperature to convert C to K (273.15)
+const float SB_c =
     2.041334e-7; // Stefan boltzman constant (2.041334e-7 KJ/m^2-hr-K^4) #corrected 12.23.14
-float H_f    = 333.5; // Heat of fusion (333.5 KJ= kg)
-float Hne_u  = 2834.0; // Heat of Vaporization (Ice to Vapor, 2834 KJ= kg)
-float C_w    = 4.18; // Water Heat Capacity (4.18 KJ/ kg-C)
-float C_s    = 2.09; // Ice heat capacity (2.09 KJ= kg= C)
-float C_p    = 1.005; // Air Heat Capacity (1.005 KJ= kg= K)
-float Ra_g   = 287.0; // Ideal Gas constant for dry air (287 J= kg= K)
-float K_vc   = 0.4; // Von Karmans constant (0.4)
-float Hs_f   = 3600.0; // Factor to convert = s into = hr (3600)
-float Rho_i  = 917.0; // Density of Ice (917 kg= m^3)
-float Rho_w  = 1000.0; // Density of Water (1000 kg= m^3)
-float Gra_v  = 9.81; // Gravitational acceleration (9.81 m= s^2)
-float W1da_y = 0.261799; // Daily frequency (2pi= 24 hr 0.261799 radians= hr)
-float Io     = 4914.0; //  Solar constant  Kj/m^2/hr
+const float H_f    = 333.5; // Heat of fusion (333.5 KJ= kg)
+const float Hne_u  = 2834.0; // Heat of Vaporization (Ice to Vapor, 2834 KJ= kg)
+const float C_w    = 4.18; // Water Heat Capacity (4.18 KJ/ kg-C)
+const float C_s    = 2.09; // Ice heat capacity (2.09 KJ= kg= C)
+const float C_p    = 1.005; // Air Heat Capacity (1.005 KJ= kg= K)
+const float Ra_g   = 287.0; // Ideal Gas constant for dry air (287 J= kg= K)
+const float K_vc   = 0.4; // Von Karmans constant (0.4)
+const float Hs_f   = 3600.0; // Factor to convert = s into = hr (3600)
+const float Rho_i  = 917.0; // Density of Ice (917 kg= m^3)
+const float Rho_w  = 1000.0; // Density of Water (1000 kg= m^3)
+const float Gra_v  = 9.81; // Gravitational acceleration (9.81 m= s^2)
+const float W1da_y = 0.261799; // Daily frequency (2pi= 24 hr 0.261799 radians= hr)
+const float Io     = 4914.0; //  Solar constant  Kj/m^2/hr
 // pi copied from snowdxv.f90
-float P_i = 3.141592653589793238462643383279502884197169399375105820974944592308; // Pi
+const float P_i = 3.141592653589793238462643383279502884197169399375105820974944592308; // Pi
 
 // data for pred-corr
-float wtol = 0.025;
-float utol = 2000.0;
+const float wtol = 0.025;
+const float utol = 2000.0;
 // from TURBFLUX()
-float tol     = 0.001;
-int nitermax  = 20;
-int ncitermax = 21;
+const float tol     = 0.001;
+const int nitermax  = 20;
+const int ncitermax = 21;
 // flag to write warnings,...etc
 
 // Global variables

--- a/src/ueb/uebpgdecls.h
+++ b/src/ueb/uebpgdecls.h
@@ -597,35 +597,35 @@ void readTextData(const char *inforcFile, float *&tvar_in, int &nrecords);
 //*******************************************************************************
 
 // js  Constant extern float set
-extern float T_0; // Temperature of freezing (0 C)
-extern float T_k; // 273.15;			// Temperature to convert C to K (273.15)
-extern float SB_c; // Stefan boltzman constant (2.041334e-7 KJ/m^2-hr-K^4) #corrected 12.23.14
-extern float H_f; // 333.5;			// Heat of fusion (333.5 KJ;  // kg)
-extern float Hne_u; // 2834.0;		// Heat of Vaporization (Ice to Vapor, 2834 KJ;  // kg)
-extern float C_w; // 4.18;			// Water Heat Capacity (4.18 KJ;  // kg;  // C)
-extern float C_s; // 2.09;			// Ice heat capacity (2.09 KJ;  // kg;  // C)
-extern float C_p; // 1.005;			// Air Heat Capacity (1.005 KJ;  // kg;  // K)
-extern float
+extern const float T_0; // Temperature of freezing (0 C)
+extern const float T_k; // 273.15;			// Temperature to convert C to K (273.15)
+extern const float SB_c; // Stefan boltzman constant (2.041334e-7 KJ/m^2-hr-K^4) #corrected 12.23.14
+extern const float H_f; // 333.5;			// Heat of fusion (333.5 KJ;  // kg)
+extern const float Hne_u; // 2834.0;		// Heat of Vaporization (Ice to Vapor, 2834 KJ;  // kg)
+extern const float C_w; // 4.18;			// Water Heat Capacity (4.18 KJ;  // kg;  // C)
+extern const float C_s; // 2.09;			// Ice heat capacity (2.09 KJ;  // kg;  // C)
+extern const float C_p; // 1.005;			// Air Heat Capacity (1.005 KJ;  // kg;  // K)
+extern const float
     Ra_g; // 287.0;			// Ideal Gas constant for dry air (287 J;  // kg;  // K)
-extern float K_vc; // 0.4;			// Von Karmans constant (0.4)
-extern float Hs_f; // 3600.0;		// Factor to convert ;  // s into ;  // hr (3600)
-extern float Rho_i; // 917.0;			// Density of Ice (917 kg;  // m^3)
-extern float Rho_w; // 1000.0;		// Density of Water (1000 kg;  // m^3)
-extern float Gra_v; // 9.81;			// Gravitational acceleration (9.81 m;  // s^2)
-extern float
+extern const float K_vc; // 0.4;			// Von Karmans constant (0.4)
+extern const float Hs_f; // 3600.0;		// Factor to convert ;  // s into ;  // hr (3600)
+extern const float Rho_i; // 917.0;			// Density of Ice (917 kg;  // m^3)
+extern const float Rho_w; // 1000.0;		// Density of Water (1000 kg;  // m^3)
+extern const float Gra_v; // 9.81;			// Gravitational acceleration (9.81 m;  // s^2)
+extern const float
     W1da_y; // 0.261799;		// Daily frequency (2pi;  // 24 hr 0.261799 radians;  // hr)
-extern float Io; // 4914.0;            //  Solar constant  Kj/m^2/hr
+extern const float Io; // 4914.0;            //  Solar constant  Kj/m^2/hr
 // pi copied from snowdxv.f90
-extern float P_i; // 3.141592653589793238462643383279502884197169399375105820974944592308;
+extern const float P_i; // 3.141592653589793238462643383279502884197169399375105820974944592308;
                   // // Pi
 
 // data for pred-corr
-extern float wtol; // 0.025;
-extern float utol; // 2000.0;
+extern const float wtol; // 0.025;
+extern const float utol; // 2000.0;
 // from TURBFLUX()
-extern float tol; // 0.001;
-extern int nitermax; // 20;
-extern int ncitermax; // 21
+extern const float tol; // 0.001;
+extern const int nitermax; // 20;
+extern const int ncitermax; // 21
 
 // #***^*-flag to write warnings,...etc ###***TBC 9.20.13
 // Global variables ###_TBC 5.6.13


### PR DESCRIPTION
Hindcasting requires resetting the current time of the BMI to its starting value after loading. This requires an additional message of `"reset_time"` to trigger it after loading from previous state.

Additionally, the UEB BMI was created to generate output files in its `Finalize()` function. This output is not used for NGEN, and the inclusion increases memory used at runtime and shutdown time after NGEN finishes running the catchments. Finally, it creates a problem for how to store and load state between runs with a different number of timesteps. Adding a compile-time option to suppress the BMI output and store only the last results from `Update()` fixes all of these problems. The suppression of outputs can be opted into with the `UEB_SUPPRESS_OUTPUTS` flag set to `ON` when building with Cmake.

## Additions

- `"reset_time"` as a `SetValue` name that will trigger the BMI to reset its time to the value defined in the config file.
- Compile-time setting for turning off the UEB BMI from generating outputs in its `Finalize()` function.
- Size of serialized data added as header used during deserialization for creating a fixed-size memory buffer for boost to read.
- `membuf` class for quick, memory-efficient wrapper for reading data during deserialization.
- Constant values created for serialization messaging variable names to prevent misspellings.

## Removals

-

## Changes

- Define global constants as `const` to differentiate them from global runtime variables.
- A calculation that was repeated in the BMI for determining data indexing locations was converted into a function `get_istep`

## Testing

1. Three runs were conducted using the test configuration and data in the `examples/test_bmi` directory. The only difference between the runs was one was compiled with the current `development` branch of UEB, one was run with this branch and output suppression off, and a last run with this branch and output suppression on. All three generated identical catchment and nexus CSV results. The UEB output files were identical between development and suppression off, and no UEB outputs were generated when suppression was on.
2. State saving and loading tested on AWS Workspace at end and start of runs.

## Notes

- Because the suppression of outputs is linked to the update in data structure to decrease memory, the ability to load a state at the beginning of a run is only supported when output suppression is on.

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
