### PR TITLE
UEB : Fix unit conversion errors in BMI calculation

### DIFF
--- a/src/bmi/OutControl.cxx
+++ b/src/bmi/OutControl.cxx
@@ -301,6 +301,7 @@ const std::array<std::string, NOUTPUTS> ueb::OutControl::output_var_names{
     "Qnet",
     "Us",
     "SWE",
+    "SWE_kg_m2",
     "tausn",
     "Pr",
     "Ps",
@@ -309,6 +310,7 @@ const std::array<std::string, NOUTPUTS> ueb::OutControl::output_var_names{
     "QEs",
     "Es",
     "SWIT",
+    "SWIT_mm",
     "QMs",
     "Q",
     "FM",
@@ -408,7 +410,7 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                       //	 thermally active soil per unit of horizontal area
                       //	 defined with respect to solid (ice) phase snow at
                       //	 0 C..	kJ/m2
-    {"SWE",           "kg m-2"          }, //  SWE	SWE	Surface snow water equivalent
+    {"SWE",           "m"          }, //  SWE	SWE	Surface snow water equivalent
                   // State variable that gives the Snow Water Equivalent (SWE)
                   // of snow on the surface.  It can be considered as the depth
                   // of water that would theoretically result if the whole snow
@@ -416,6 +418,7 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                   // and ablation on top of a substrate layer which may be
                   // ground or glacier.  In the case that the substrate is
                   // glacier this does not track the quantity of glacier ice. m
+    {"SWE_kg_m2",     "kg m-2"     },
     {"tausn",         "1"          }, //  tausn	tausn	Dimensionless snow surface age
                     // Dimensionless age of the snow surface state variable to
                     // account for aging of the snow surface dependent on snow
@@ -440,10 +443,11 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                             //(wind and turbulence).	kJ/m2/hr
     {"Es",            "m"          }, //  E	E	Surface sublimation	Amount of water removed
                  // from the snow surface by sublimation	m
-    {"SWIT",          "mm"     }, //  SWIT 	SWIT 	Total outflow 	Total outflow from the
+    {"SWIT",          "mm hr-1"    }, //  SWIT 	SWIT 	Total outflow 	Total outflow from the
                         // base of the snowpack (and glacier). This includes rainfall,
                         // melt from seasonal snow and melt from glaciated surface.
                         // m/hr
+    {"SWIT_mm",       "mm"         },
     {"QMs",           "kJ m-2 hr-1"}, //  Qm	Qm	Outflow energy flux
                             // Energy removed from the snowpack by total outflow
                             // kJ/m2/hr

--- a/src/bmi/OutControl.cxx
+++ b/src/bmi/OutControl.cxx
@@ -301,7 +301,6 @@ const std::array<std::string, NOUTPUTS> ueb::OutControl::output_var_names{
     "Qnet",
     "Us",
     "SWE",
-    "SWE_kg_m2",
     "tausn",
     "Pr",
     "Ps",
@@ -310,7 +309,6 @@ const std::array<std::string, NOUTPUTS> ueb::OutControl::output_var_names{
     "QEs",
     "Es",
     "SWIT",
-    "SWIT_mm",
     "QMs",
     "Q",
     "FM",
@@ -354,7 +352,9 @@ const std::array<std::string, NOUTPUTS> ueb::OutControl::output_var_names{
     "SWIGM",
     "SWISM",
     "SWIR",
-    "errMB"
+    "errMB",
+    "SWE_kg_m2",
+    "SWIT_mm"
 };
 
 const std::map<std::string, std::string> ueb::OutControl::output_var_units{
@@ -418,7 +418,6 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                   // and ablation on top of a substrate layer which may be
                   // ground or glacier.  In the case that the substrate is
                   // glacier this does not track the quantity of glacier ice. m
-    {"SWE_kg_m2",     "kg m-2"     },
     {"tausn",         "1"          }, //  tausn	tausn	Dimensionless snow surface age
                     // Dimensionless age of the snow surface state variable to
                     // account for aging of the snow surface dependent on snow
@@ -447,7 +446,6 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                         // base of the snowpack (and glacier). This includes rainfall,
                         // melt from seasonal snow and melt from glaciated surface.
                         // m/hr
-    {"SWIT_mm",       "mm"         },
     {"QMs",           "kJ m-2 hr-1"}, //  Qm	Qm	Outflow energy flux
                             // Energy removed from the snowpack by total outflow
                             // kJ/m2/hr
@@ -643,6 +641,9 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                     // in the computation.  It is included as a check on the
                     // functioning of the model and if significantly different from
                     // 0 is indicative of a problem.	m
+    {"SWE_kg_m2",     "kg m-2"     },
+    {"SWIT_mm",       "mm"         },
+
 };
 
 std::ostream& operator<<(std::ostream& os, ueb::OutControl const& p) { // operator<<

--- a/src/bmi/OutControl.cxx
+++ b/src/bmi/OutControl.cxx
@@ -441,9 +441,9 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                             // transferred from the snow surface to the atmosphere by
                             // water vapor carried in air movement
                             //(wind and turbulence).	kJ/m2/hr
-    {"Es",            "mm"          }, //  E	E	Surface sublimation	Amount of water removed
+    {"Es",            "m"          }, //  E	E	Surface sublimation	Amount of water removed
                  // from the snow surface by sublimation	m
-    {"SWIT",          "mm hr-1"    }, //  SWIT 	SWIT 	Total outflow 	Total outflow from the
+    {"SWIT",          "m hr-1"    }, //  SWIT 	SWIT 	Total outflow 	Total outflow from the
                         // base of the snowpack (and glacier). This includes rainfall,
                         // melt from seasonal snow and melt from glaciated surface.
                         // m/hr

--- a/src/bmi/OutControl.cxx
+++ b/src/bmi/OutControl.cxx
@@ -441,7 +441,7 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                             // transferred from the snow surface to the atmosphere by
                             // water vapor carried in air movement
                             //(wind and turbulence).	kJ/m2/hr
-    {"Es",            "m"          }, //  E	E	Surface sublimation	Amount of water removed
+    {"Es",            "mm"          }, //  E	E	Surface sublimation	Amount of water removed
                  // from the snow surface by sublimation	m
     {"SWIT",          "mm hr-1"    }, //  SWIT 	SWIT 	Total outflow 	Total outflow from the
                         // base of the snowpack (and glacier). This includes rainfall,

--- a/src/bmi/OutControl.cxx
+++ b/src/bmi/OutControl.cxx
@@ -408,7 +408,7 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                       //	 thermally active soil per unit of horizontal area
                       //	 defined with respect to solid (ice) phase snow at
                       //	 0 C..	kJ/m2
-    {"SWE",           "m"          }, //  SWE	SWE	Surface snow water equivalent
+    {"SWE",           "kg m-2"          }, //  SWE	SWE	Surface snow water equivalent
                   // State variable that gives the Snow Water Equivalent (SWE)
                   // of snow on the surface.  It can be considered as the depth
                   // of water that would theoretically result if the whole snow
@@ -440,7 +440,7 @@ const std::map<std::string, std::string> ueb::OutControl::output_var_units{
                             //(wind and turbulence).	kJ/m2/hr
     {"Es",            "m"          }, //  E	E	Surface sublimation	Amount of water removed
                  // from the snow surface by sublimation	m
-    {"SWIT",          "m hr-1"     }, //  SWIT 	SWIT 	Total outflow 	Total outflow from the
+    {"SWIT",          "mm"     }, //  SWIT 	SWIT 	Total outflow 	Total outflow from the
                         // base of the snowpack (and glacier). This includes rainfall,
                         // melt from seasonal snow and melt from glaciated surface.
                         // m/hr

--- a/src/bmi/OutControl.hxx
+++ b/src/bmi/OutControl.hxx
@@ -6,7 +6,7 @@
 #include <map>
 #include <string>
 
-#define NOUTPUTS 70
+#define NOUTPUTS 72
 
 namespace ueb {
 class OutControl;

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -770,13 +770,13 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
     }
 
     auto it_out = std::find(
-     ueb::OutControl::output_var_names.begin(),
-     ueb::OutControl::output_var_names.end(),
-     name
+       ueb::OutControl::output_var_names.begin(),
+       ueb::OutControl::output_var_names.end(),
+       name
     );
 
     if (it_out != ueb::OutControl::output_var_names.end()) {
-     int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
+       int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
 
  #ifdef UEB_SUPPRESS_OUTPUTS
       // value will always be the first when not recording previous results

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -770,20 +770,20 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
     }
 
     auto it_out = std::find(
-       ueb::OutControl::output_var_names.begin(),
-       ueb::OutControl::output_var_names.end(),
-       name
+        ueb::OutControl::output_var_names.begin(),
+	ueb::OutControl::output_var_names.end(),
+        name
     );
 
     if (it_out != ueb::OutControl::output_var_names.end()) {
-       int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
+        int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
 
- #ifdef UEB_SUPPRESS_OUTPUTS
+  #ifdef UEB_SUPPRESS_OUTPUTS
       // value will always be the first when not recording previous results
       int ostep = 0;
- #else
+  #else
       int ostep = this->get_istep() - 1;
- #endif
+  #endif
 
       // BMI-facing conversion only:
       // UEB internal SWE is m; NWM SNEQV expects kg m-2.

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -769,9 +769,10 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
         return (void*)NULL;
     }
 
+
     auto it_out = std::find(
         ueb::OutControl::output_var_names.begin(),
-	    ueb::OutControl::output_var_names.end(),
+        ueb::OutControl::output_var_names.end(),
         name
     );
 
@@ -779,47 +780,50 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
         int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
 
   #ifdef UEB_SUPPRESS_OUTPUTS
-      // value will always be the first when not recording previous results
-      int ostep = 0;
+        int ostep = 0;
   #else
-      int ostep = this->get_istep() - 1;
+        int ostep = this->get_istep() - 1;
   #endif
 
-      // BMI-facing conversion only:
-      // UEB internal SWE is m; NWM SNEQV expects kg m-2.
-      if (name.compare("SWE_kg_m2") == 0) {
-          int swe_i = std::distance(
-              ueb::OutControl::output_var_names.begin(),
-              std::find(
-                  ueb::OutControl::output_var_names.begin(),
-                  ueb::OutControl::output_var_names.end(),
-                  "SWE"
-              )
-          );
+        if (name.compare("SWE_kg_m2") == 0) {
+            auto swe_it = std::find(
+                ueb::OutControl::output_var_names.begin(),
+                ueb::OutControl::output_var_names.end(),
+                "SWE"
+            );
 
-          _swe_kg_m2 = _outvarArray[0][swe_i][ostep] * 1000.0f;
-          return (void*)&_swe_kg_m2;
-      }
+            if (swe_it == ueb::OutControl::output_var_names.end()) {
+                return (void*)NULL;
+            }
 
-      if (name.compare("SWIT_mm") == 0) {
-          int swit_i = std::distance(
-              ueb::OutControl::output_var_names.begin(),
-              std::find(
-                  ueb::OutControl::output_var_names.begin(),
-                  ueb::OutControl::output_var_names.end(),
-                  "SWIT"
-              )
-          );
+            int swe_i = std::distance(ueb::OutControl::output_var_names.begin(), swe_it);
+            _swe_kg_m2 = _outvarArray[0][swe_i][ostep] * 1000.0f;
+            return (void*)&_swe_kg_m2;
+        }
 
-          _swit_mm = _outvarArray[0][swit_i][ostep] *
-                     (float)(this->GetTimeStep() / 3600.0) *
-                     1000.0f;
-          return (void*)&_swit_mm;
-      }
+        if (name.compare("SWIT_mm") == 0) {
+            auto swit_it = std::find(
+                ueb::OutControl::output_var_names.begin(),
+                ueb::OutControl::output_var_names.end(),
+                "SWIT"
+            );
 
-      return (void*)&_outvarArray[0][i][ostep];
+            if (swit_it == ueb::OutControl::output_var_names.end()) {
+                return (void*)NULL;
+            }
+
+            int swit_i = std::distance(ueb::OutControl::output_var_names.begin(), swit_it);
+            _swit_mm = _outvarArray[0][swit_i][ostep] *
+                       (float)(this->GetTimeStep() / 3600.0) *
+                       1000.0f;
+            return (void*)&_swit_mm;
+        }
+
+        if (i < numOut) {
+            return (void*)&_outvarArray[0][i][ostep];
+        }
     }
-    
+
     return (void*)NULL;
 }
 

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -770,34 +770,51 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
     }
 
     auto it_out = std::find(
-      ueb::OutControl::output_var_names.begin(),
-      ueb::OutControl::output_var_names.end(),
-      name
+     ueb::OutControl::output_var_names.begin(),
+     ueb::OutControl::output_var_names.end(),
+     name
     );
 
     if (it_out != ueb::OutControl::output_var_names.end()) {
-      int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
+     int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
 
-  #ifdef UEB_SUPPRESS_OUTPUTS
+ #ifdef UEB_SUPPRESS_OUTPUTS
       // value will always be the first when not recording previous results
       int ostep = 0;
-  #else
+ #else
       int ostep = this->get_istep() - 1;
-  #endif
+ #endif
 
       // BMI-facing conversion only:
       // UEB internal SWE is m; NWM SNEQV expects kg m-2.
-      if (name.compare("SWE") == 0) {
-        _swe_kg_m2 = _outvarArray[0][i][ostep] * 1000.0f;
-        return (void*)&_swe_kg_m2;
+      if (name.compare("SWE_kg_m2") == 0) {
+          int swe_i = std::distance(
+              ueb::OutControl::output_var_names.begin(),
+              std::find(
+                  ueb::OutControl::output_var_names.begin(),
+                  ueb::OutControl::output_var_names.end(),
+                  "SWE"
+              )
+          );
+
+          _swe_kg_m2 = _outvarArray[0][swe_i][ostep] * 1000.0f;
+          return (void*)&_swe_kg_m2;
       }
 
-      // UEB internal SWIT is m/hr; NWM ACSNOW expects timestep depth in mm.
-      if (name.compare("SWIT") == 0) {
-        _swit_mm = _outvarArray[0][i][ostep] *
-                   (float)(this->GetTimeStep() / 3600.0) *
-                   1000.0f;
-        return (void*)&_swit_mm;
+      if (name.compare("SWIT_mm") == 0) {
+          int swit_i = std::distance(
+              ueb::OutControl::output_var_names.begin(),
+              std::find(
+                  ueb::OutControl::output_var_names.begin(),
+                  ueb::OutControl::output_var_names.end(),
+                  "SWIT"
+              )
+          );
+
+          _swit_mm = _outvarArray[0][swit_i][ostep] *
+                     (float)(this->GetTimeStep() / 3600.0) *
+                     1000.0f;
+          return (void*)&_swit_mm;
       }
 
       return (void*)&_outvarArray[0][i][ostep];

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -771,7 +771,7 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
 
     auto it_out = std::find(
         ueb::OutControl::output_var_names.begin(),
-	     ueb::OutControl::output_var_names.end(),
+	    ueb::OutControl::output_var_names.end(),
         name
     );
 

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -771,7 +771,7 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
 
     auto it_out = std::find(
         ueb::OutControl::output_var_names.begin(),
-	ueb::OutControl::output_var_names.end(),
+	    ueb::OutControl::output_var_names.end(),
         name
     );
 

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -797,6 +797,19 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
             }
 
             int swe_i = std::distance(ueb::OutControl::output_var_names.begin(), swe_it);
+
+            /* UEB native SWE is water-equivalent depth in meters.
+             * NWM SNEQV expects mass per unit area in kg m-2.
+             *
+             * Conversion:
+             *   SWE_kg_m2 = SWE_m * rho_water
+             *             = SWE_m * 1000 kg m-3
+             *
+             * This is equivalent to the common shortcut that 1 mm water
+             * depth equals 1 kg m-2, but here the source value is meters,
+             * so the multiplier is 1000.
+             */
+            	    
             _swe_kg_m2 = _outvarArray[0][swe_i][ostep] * 1000.0f;
             return (void*)&_swe_kg_m2;
         }

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -771,7 +771,7 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
 
     auto it_out = std::find(
         ueb::OutControl::output_var_names.begin(),
-	    ueb::OutControl::output_var_names.end(),
+	     ueb::OutControl::output_var_names.end(),
         name
     );
 

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -770,23 +770,39 @@ void* ueb::BmiUEB::GetValuePtr(std::string name) {
     }
 
     auto it_out = std::find(
-        ueb::OutControl::output_var_names.begin(),
-        ueb::OutControl::output_var_names.end(),
-        name
+      ueb::OutControl::output_var_names.begin(),
+      ueb::OutControl::output_var_names.end(),
+      name
     );
+
     if (it_out != ueb::OutControl::output_var_names.end()) {
-        int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
-#ifdef UEB_SUPPRESS_OUTPUTS
-        // value will always be the first when not recording previous results
-        int ostep = 0;
-#else
-        int ostep = this->get_istep() - 1;
-#endif
-        // need to check for gridded model
-        // this only return the first grid cell's value
-        // How about other grid cells?
-        return (void*)&_outvarArray[0][i][ostep];
+      int i = std::distance(ueb::OutControl::output_var_names.begin(), it_out);
+
+  #ifdef UEB_SUPPRESS_OUTPUTS
+      // value will always be the first when not recording previous results
+      int ostep = 0;
+  #else
+      int ostep = this->get_istep() - 1;
+  #endif
+
+      // BMI-facing conversion only:
+      // UEB internal SWE is m; NWM SNEQV expects kg m-2.
+      if (name.compare("SWE") == 0) {
+        _swe_kg_m2 = _outvarArray[0][i][ostep] * 1000.0f;
+        return (void*)&_swe_kg_m2;
+      }
+
+      // UEB internal SWIT is m/hr; NWM ACSNOW expects timestep depth in mm.
+      if (name.compare("SWIT") == 0) {
+        _swit_mm = _outvarArray[0][i][ostep] *
+                   (float)(this->GetTimeStep() / 3600.0) *
+                   1000.0f;
+        return (void*)&_swit_mm;
+      }
+
+      return (void*)&_outvarArray[0][i][ostep];
     }
+    
     return (void*)NULL;
 }
 

--- a/src/bmi/bmi_ueb.hxx
+++ b/src/bmi/bmi_ueb.hxx
@@ -129,6 +129,8 @@ class BmiUEB : public bmi::Bmi {
     void serialize(Archive& ar, const unsigned int version);
     vecbuf<char> m_serialized;
     uint64_t m_serialized_length; // needs stable location for GetValuePtr
+    float _swe_kg_m2;
+    float _swit_mm;
     void load_serialized(char* data);
     void clear_serialized();
     void new_serialized();


### PR DESCRIPTION
**Issue**

UEB exposed:

SWIT in m hr⁻¹ (rate) while NWM expects mm (depth)
SWE in m (depth) while NWM expects kg m⁻² (mass)

This caused NGEN errors:

Unable to convert m hr-1 to mm
Unable to convert m to kg/m2

**Fix**

Instead of modifying existing variables, new BMI output variables were introduced:

SWIT_mm   → mm
SWE_kg_m2 → kg m⁻²

Computed as:

SWIT_mm   = SWIT × timestep_seconds / 3600 × 1000
SWE_kg_m2 = SWE × 1000

The original variables remain unchanged:

SWIT → m hr⁻¹
SWE  → m

**Why**

Preserves UEB native variable semantics
Avoids redefining existing variables
Aligns with NWM expectations (ACSNOW, SNEQV)
Keeps consistency with fixes in Snow-17, CFE, and Sac-SMA

**Result**
Eliminates unit conversion warnings
Produces physically correct NWM-compatible outputs
Maintains backward compatibility and clarity

**Final Mapping**
Variable	Meaning	Units
SWIT	snow/rain outflow rate	m hr⁻¹
SWIT_mm	timestep-integrated outflow (NWM ACSNOW)	mm
SWE	snow water equivalent depth	m
SWE_kg_m2	snow water equivalent (NWM SNEQV)	kg m⁻²
