### PR TITLE
Adding check to suppress duplicate warnings

### DIFF
--- a/src/ueb/canopy.cpp
+++ b/src/ueb/canopy.cpp
@@ -619,16 +619,27 @@ void TURBFLUX(
 
             // ###### 9.21.13 to avoid div by 0 when Rkina + 1*Rkinl + 1*Rkinc evaluate to zero 0.01
             // added TBC_9.21.13
-            if (radFracdenom == 0) {
+	    if (radFracdenom == 0) {
+                static int warned = 0;
+
                 radFracdenom += 0.01;
-                canopy_ss << "Warning! a zero denominator! the sum of turbulent conductances Rkina "
-                             "+ 1*Rkinl + 1*Rkinc evaluates to zero"
-                          << endl;
-                canopy_ss << "added 0.01 to avoid numerical error; Need checking results" << endl;
-                LOG(canopy_ss.str(), LogLevel::SEVERE);
-                canopy_ss.str("");
-                // getchar();
+
+                if (warned == 0) {
+                    canopy_ss << "Warning! a zero denominator! the sum of turbulent conductances Rkina "
+                                 "+ 1*Rkinl + 1*Rkinc evaluates to zero"
+                              << endl;
+                    canopy_ss << "added 0.01 to avoid numerical error; Need checking results" << endl;
+                    LOG(canopy_ss.str(), LogLevel::SEVERE);
+                    canopy_ss.str("");
+                    warned = 1;
+                }
+                else if (warned == 1) {
+                    LOG(LogLevel::SEVERE,
+                        "Warning! zero turbulent-conductance denominator occurred again; further warnings suppressed");
+                    warned = 2;
+                }
             }
+	    
             Tac = (Tc * Rkinl + Tss * Rkinc + Ta * Rkina) /
                   radFracdenom; //(1*Rkina + 1*Rkinl + 1*Rkinc);
             Eac = (Esc * Rkinl + Ess * Rkinc + Ea * Rkina) /

--- a/src/ueb/uebinputs.cpp
+++ b/src/ueb/uebinputs.cpp
@@ -122,13 +122,26 @@ void readSiteVars(const char *inpFile, sitevar *svArr) {
             sscanf(headerLine, "%s %s ", svArr[i].svFile, svArr[i].svVarName);
             break;
         default:
-            uebinputs_ss << "Wrong site variable type; has to be -1 (Use default values), 0 "
-                            "(single value) or 1 (2D netcdf)"
-                         << endl;
-            uebinputs_ss << "Using default value..." << endl;
-            LOG(uebinputs_ss.str(), LogLevel::SEVERE);
-            uebinputs_ss.str("");
-            svArr[i].svdefValue = vardefaults[i];
+            {
+                static int warned = 0;
+
+                if (warned == 0) {
+                    uebinputs_ss << "Wrong site variable type; has to be -1 (Use default values), 0 "
+                                    "(single value) or 1 (2D netcdf)"
+                                 << endl;
+                    uebinputs_ss << "Using default value..." << endl;
+                    LOG(uebinputs_ss.str(), LogLevel::SEVERE);
+                    uebinputs_ss.str("");
+                    warned = 1;
+                }
+                else if (warned == 1) {
+                    LOG(LogLevel::SEVERE,
+                        "Wrong site variable type occurred again; further warnings suppressed");
+                    warned = 2;
+                }
+
+                svArr[i].svdefValue = vardefaults[i];
+            }
         }
         // i++;
         // headerLine[0] = 0;
@@ -171,10 +184,24 @@ void readSiteVars(const char* inpFile, float svSValue[], char* svFile[], char* s
 				sscanf(headerLine,"%s %s",svFile[i],svVarName[i]);
 				break;			
 			default:
-				uebinputs_ss <<"Wrong site variable type; has to be -1 (Use default values), 0 (single value) or 1 (2D netcdf)"<<endl;
-				uebinputs_ss <<"Using default value..."<<endl;
-				LOG(uebinputs_ss.str(), LogLevel::SEVERE); uebinputs_ss.str("");
-				break;       //exit 
+                        {
+                            static int warned = 0;
+
+                            if (warned == 0) {
+                                uebinputs_ss <<"Wrong site variable type; has to be -1 (Use default values), 0 (single value) or 1 (2D netcdf)"<<endl;
+                                uebinputs_ss <<"Using default value..."<<endl;
+                                LOG(uebinputs_ss.str(), LogLevel::SEVERE);
+                                uebinputs_ss.str("");
+                                warned = 1;
+                            }
+                            else if (warned == 1) {
+                                LOG(LogLevel::SEVERE,
+                                    "Wrong site variable type occurred again; further warnings suppressed");
+                                warned = 2;
+                            }
+
+                            break;
+                        }
 			}
 			i++; //increment i
 			headerLine[0] = ' ';


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

https://jira.nextgenwaterprediction.com/browse/NGWPC-10674


**UEB Logging Fix – Duplicate Warning Suppression**

When running compound workflows (Noah-OWP, SFT, SMP, Sac-SMA, T-Route, UEB), the UEB BMI implementation produces repeated SEVERE log messages at every timestep or invocation, leading to excessive log noise and reduced debuggability.

The main issues occur in:

canopy.cpp → repeated “zero denominator” warnings
uebinputs.cpp → repeated “Wrong site variable type” warnings

These messages are triggered frequently under valid runtime conditions (e.g., fallback/default handling), causing log flooding in ngen-cal runs.

**Fix Approach**

Apply a static warning throttle pattern (same as used in PET):

Log the full warning only once
Log a single follow-up suppression message
Suppress all further repeats

**Outcome**
Prevents duplicate log spam
Retains visibility of the issue
Improves readability and debugging of ngen-cal logs without altering model behavior