### PR TITLE
Duplicate warning suppressing2 mohammed

### DIFF
--- a/src/ueb/canopy.cpp
+++ b/src/ueb/canopy.cpp
@@ -649,11 +649,22 @@ void TURBFLUX(
             // ###### 9.22.13 observed Tac values close to -273 which may lead to Tack = 0
             // TBC_9.22.13
             if (Tack == 0) {
+                static int warned = 0;
+
                 Tack += 1.0;
-                canopy_ss << "Error! Surface temp in function Turbflux() Tack = 0" << endl;
-                canopy_ss << "added 1 to avoid numerical error; Need checking results" << endl;
-                LOG(canopy_ss.str(), LogLevel::WARNING);
-                canopy_ss.str("");
+
+                if (warned == 0) {
+                    canopy_ss << "Error! Surface temp in function Turbflux() Tack = 0" << endl;
+                    canopy_ss << "added 1 to avoid numerical error; Need checking results" << endl;
+                    LOG(canopy_ss.str(), LogLevel::WARNING);
+                    canopy_ss.str("");
+                    warned = 1;
+                }
+                else if (warned == 1) {
+                    LOG(LogLevel::WARNING,
+                        "Surface temp in function Turbflux() Tack = 0 occurred again; further warnings suppressed");
+                    warned = 2;
+                }
                 // getchar();
             }
 

--- a/src/ueb/canopy.cpp
+++ b/src/ueb/canopy.cpp
@@ -654,7 +654,7 @@ void TURBFLUX(
                 Tack += 1.0;
 
                 if (warned == 0) {
-                    canopy_ss << "Error! Surface temp in function Turbflux() Tack = 0" << endl;
+                    canopy_ss << "Surface temp in function Turbflux() Tack = 0" << endl;
                     canopy_ss << "added 1 to avoid numerical error; Need checking results" << endl;
                     LOG(canopy_ss.str(), LogLevel::WARNING);
                     canopy_ss.str("");


### PR DESCRIPTION
https://jira.nextgenwaterprediction.com/browse/NGWPC-10711

**Issue**
During coupled ngen-cal workflows, the UEB canopy energy balance routines produced repeated WARNING/SEVERE log messages related to numerical safeguards, particularly:

zero turbulent-conductance denominator handling
Tack == 0 temperature correction logic in TURBFLUX()

These warnings could be emitted repeatedly across timesteps, causing excessive log noise and making debugging difficult.

**Fix Approach**

Applied a lightweight static warning throttle pattern in canopy.cpp:

Log the full warning only once
Log a single suppression message on the next occurrence
Suppress all additional repeated warnings

No numerical behavior or model physics were changed; only logging behavior was updated.

**Outcome**
Reduces duplicate warning spam in ngen-cal logs
Preserves visibility of important numerical stability events
Improves readability and debugging of coupled model runs
Maintains existing UEB computational behavior and safeguards
