### PR TITLE
Fix for incorrectly identified log messages

### DIFF
--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -28,9 +28,9 @@ void ueb::BmiUEB::Initialize(std::string config_file) {
 
     // Initialize the Error, Warning and Trapping System
     #ifdef EWTS_HAVE_NGEN_BRIDGE    
-        EwtsInit(EWTS_ID_UEB, true);
+        EwtsInit(UEB_MODULE_ID, true);
     #else
-        EwtsInit(EWTS_ID_UEB, false);
+        EwtsInit(UEB_MODULE_ID, false);
     #endif
     LOG(LogLevel::INFO, "Initializing UEB");
 

--- a/src/utilities/Logger.hpp
+++ b/src/utilities/Logger.hpp
@@ -1,13 +1,17 @@
 #ifndef UEB_LOGGER_HPP
 #define UEB_LOGGER_HPP
 
-#include "ewts/logger.hpp"
 #include "ewts/module_constants.hpp"
+#include "ewts/logger.hpp"
+#include "ewts/log_levels.hpp"
+
+#define LOG(...) ::ewts::GetLogger(::ewts::modules::EWTS_ID_UEB).Log(__VA_ARGS__)
+#define GetLogLevel() ::ewts::GetLogger(::ewts::modules::EWTS_ID_UEB).GetLogLevel()
+#define IsLoggingEnabled() ::ewts::GetLogger(::ewts::modules::EWTS_ID_UEB).IsLoggingEnabled()
 
 using ewts::EwtsInit;
 using ewts::LogLevel;
 
-// Provide the constant in the global namespace:
-inline constexpr const char* EWTS_ID_UEB = ewts::modules::EWTS_ID_UEB;
+inline constexpr const char* UEB_MODULE_ID = ewts::modules::EWTS_ID_UEB;
 
 #endif /* UEB_LOGGER_HPP */


### PR DESCRIPTION
Define LOG in submodule instead of relying on generic definition in ewts library which was causing log messages to be incorrectly identified in the logs.