### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(UEB_SUPPRESS_OUTPUTS "Build where UEB BMI's Finalize() will not create outputs" OFF)
 
-option(USE_EWTS "Build UEB BMI with EWTS logging" OFF)
+option(USE_EWTS "Build UEB BMI with EWTS logging" ON)
 
 # -----------------------------------------------------------------------------
 # Find the Boost library and configure usage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,6 @@ option(UEB_SUPPRESS_OUTPUTS "Build where UEB BMI's Finalize() will not create ou
 
 option(USE_EWTS "Build UEB BMI with EWTS logging" OFF)
 
-if(USE_EWTS)
-    message("-- UEB compiled with EWTS logging")
-    add_compile_definitions(USE_EWTS)
-endif()
-
 # -----------------------------------------------------------------------------
 # Find the Boost library and configure usage
 set(Boost_USE_STATIC_LIBS OFF)
@@ -50,6 +45,12 @@ endif()
 if(UEB_SUPPRESS_OUTPUTS)
     message("-- UEB compiled to not create its own outputs")
     add_compile_definitions(UEB_SUPPRESS_OUTPUTS)
+endif()
+
+message("-- ueb-bmi CMakeLists USE_EWTS = ${USE_EWTS}")
+if(USE_EWTS)
+    message("-- UEB compiled with EWTS logging")
+    add_compile_definitions(UEB_USE_EWTS)
 endif()
 
 link_libraries(Boost::serialization)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# ueb-bmi CMakeLists.txt
+# ngen/extern/ueb-bmi CMakeLists.txt
 #
 
 cmake_minimum_required(VERSION 3.0)
@@ -45,12 +45,6 @@ endif()
 if(UEB_SUPPRESS_OUTPUTS)
     message("-- UEB compiled to not create its own outputs")
     add_compile_definitions(UEB_SUPPRESS_OUTPUTS)
-endif()
-
-message("-- ueb-bmi CMakeLists USE_EWTS = ${USE_EWTS}")
-if(USE_EWTS)
-    message("-- UEB compiled with EWTS logging")
-    add_compile_definitions(UEB_USE_EWTS)
 endif()
 
 link_libraries(Boost::serialization)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,13 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(UEB_SUPPRESS_OUTPUTS "Build where UEB BMI's Finalize() will not create outputs" OFF)
 
+option(USE_EWTS "Build UEB BMI with EWTS logging" OFF)
+
+if(USE_EWTS)
+    message("-- UEB compiled with EWTS logging")
+    add_compile_definitions(USE_EWTS)
+endif()
+
 # -----------------------------------------------------------------------------
 # Find the Boost library and configure usage
 set(Boost_USE_STATIC_LIBS OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,20 +66,28 @@ set_target_properties(bmiuebcxx PROPERTIES
        PUBLIC_HEADER utilities/Logger.hpp
 )
 
-# --- EWTS (installed from nwm-ewts) ---
-find_package(ewts CONFIG REQUIRED)
+option(USE_EWTS "Build UEB with EWTS logging" ON)
+message("-- UEB CMakeLists USE_EWTS = ${USE_EWTS}")
+if(USE_EWTS)
+    message("-- UEB compiled with EWTS logging")
 
-target_link_libraries(bmiuebcxx
-    ewts::ewts_cpp
-    "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed"
-)
-target_compile_definitions(bmiuebcxx PRIVATE USE_EWTS)
+    # --- EWTS (installed from nwm-ewts) ---
+    find_package(ewts CONFIG REQUIRED)
 
-target_link_libraries(run_bmiuebcxx
-    ewts::ewts_cpp
-    "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed"
-)
-target_compile_definitions(run_bmiuebcxx PRIVATE USE_EWTS)
+    target_link_libraries(bmiuebcxx
+        ewts::ewts_cpp
+        "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed"
+    )
+    target_compile_definitions(bmiuebcxx PRIVATE UEB_USE_EWTS)
+
+    target_link_libraries(run_bmiuebcxx
+        ewts::ewts_cpp
+        "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed"
+    )
+    target_compile_definitions(run_bmiuebcxx PRIVATE UEB_USE_EWTS)
+else()
+    message("-- UEB compiled with stdout fallback logging")
+endif()
 
 include(GNUInstallDirs)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,13 +73,13 @@ target_link_libraries(bmiuebcxx
     ewts::ewts_cpp
     "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed"
 )
-target_compile_definitions(bmiuebcxx PRIVATE EWTS_HAVE_NGEN_BRIDGE)
+target_compile_definitions(bmiuebcxx PRIVATE USE_EWTS)
 
 target_link_libraries(run_bmiuebcxx
     ewts::ewts_cpp
     "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed"
 )
-target_compile_definitions(run_bmiuebcxx PRIVATE EWTS_HAVE_NGEN_BRIDGE)
+target_compile_definitions(run_bmiuebcxx PRIVATE USE_EWTS)
 
 include(GNUInstallDirs)
 

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -27,9 +27,13 @@ std::stringstream bmi_ueb_ss("");
 void ueb::BmiUEB::Initialize(std::string config_file) {
 
     // Initialize the Error, Warning and Trapping System
-#ifdef USE_EWTS    
-        EwtsInit(UEB_MODULE_ID, true);
+#ifdef UEB_USE_EWTS    
+    #pragma message("ueb-bmi.bmi_ueb.Initialize: UEB_USE_EWTS ON")
+    EwtsInit(UEB_MODULE_ID, true);
+#else
+    #pragma message("ueb-bmi.bmi_ueb.Initialize: UEB_USE_EWTS OFF")
 #endif
+
     LOG(LogLevel::INFO, "Initializing UEB");
 
     if (config_file.compare("") != 0) {

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -26,8 +26,8 @@ std::stringstream bmi_ueb_ss("");
 
 void ueb::BmiUEB::Initialize(std::string config_file) {
 
-    // Initialize the Error, Warning and Trapping System
 #ifdef UEB_USE_EWTS    
+    // Initialize the Error and Warning Trapping System
     #pragma message("ueb-bmi.bmi_ueb.Initialize: UEB_USE_EWTS ON")
     EwtsInit(UEB_MODULE_ID, true);
 #else

--- a/src/bmi/bmi_ueb.cxx
+++ b/src/bmi/bmi_ueb.cxx
@@ -27,11 +27,9 @@ std::stringstream bmi_ueb_ss("");
 void ueb::BmiUEB::Initialize(std::string config_file) {
 
     // Initialize the Error, Warning and Trapping System
-    #ifdef EWTS_HAVE_NGEN_BRIDGE    
+#ifdef USE_EWTS    
         EwtsInit(UEB_MODULE_ID, true);
-    #else
-        EwtsInit(UEB_MODULE_ID, false);
-    #endif
+#endif
     LOG(LogLevel::INFO, "Initializing UEB");
 
     if (config_file.compare("") != 0) {

--- a/src/utilities/Logger.hpp
+++ b/src/utilities/Logger.hpp
@@ -1,7 +1,7 @@
 #ifndef UEB_LOGGER_HPP
 #define UEB_LOGGER_HPP
 
-#ifdef USE_EWTS
+#ifdef UEB_USE_EWTS
 #include "ewts/module_constants.hpp"
 #include "ewts/logger.hpp"
 #include "ewts/log_levels.hpp"
@@ -17,9 +17,13 @@ inline constexpr const char* UEB_MODULE_ID = ewts::modules::EWTS_ID_UEB;
 
 #else
 // Log all messages to stdout
+#include <chrono>
 #include <cstdarg>
 #include <cstddef>
 #include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -37,12 +41,31 @@ enum class LogLevel {
     FATAL = 50
 };
 
-inline bool IsLoggingEnabled() {
-    return true;  // always enabled in fallback
+
+inline std::string utc_timestamp() {
+    using clock = std::chrono::system_clock;
+    auto now = clock::now();
+    auto tt = clock::to_time_t(now);
+
+    std::tm tm{};
+    gmtime_r(&tt, &tm);
+
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now.time_since_epoch()) % 1000;
+
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S")
+        << '.' << std::setw(3) << std::setfill('0') << ms.count()
+        << 'Z';
+
+    return oss.str();
 }
 
-inline LogLevel GetLogLevel() {
-    return LogLevel::INFO;  // simple default
+inline std::string_view rstrip_newline(std::string_view s) {
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r')) {
+        s.remove_suffix(1);
+    }
+    return s;
 }
 
 inline const char* level_to_string(LogLevel level) {
@@ -58,12 +81,25 @@ inline const char* level_to_string(LogLevel level) {
 
 inline void Log(LogLevel level, std::string_view message) {
     std::ostringstream oss;
-    oss << UEB_MODULE_ID << " "
+
+    message = rstrip_newline(message);
+
+    oss << utc_timestamp() << " "
+        << UEB_MODULE_ID << " "
         << level_to_string(level) << " "
         << message << '\n';
 
     std::cout << oss.str() << std::flush;   
 }
+
+inline bool IsLoggingEnabled() {
+    return true;  // always enabled in fallback
+}
+
+inline LogLevel GetLogLevel() {
+    return LogLevel::INFO;  // simple default
+}
+
 
 inline void Log(std::string_view message, LogLevel level) {
     Log(level, message);

--- a/src/utilities/Logger.hpp
+++ b/src/utilities/Logger.hpp
@@ -2,6 +2,10 @@
 #define UEB_LOGGER_HPP
 
 #ifdef UEB_USE_EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Using EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
 #include "ewts/module_constants.hpp"
 #include "ewts/logger.hpp"
 #include "ewts/log_levels.hpp"
@@ -16,7 +20,10 @@ using ewts::LogLevel;
 inline constexpr const char* UEB_MODULE_ID = ewts::modules::EWTS_ID_UEB;
 
 #else
-// Log all messages to stdout
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Log messages written to STDOUT
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
 #include <chrono>
 #include <cstdarg>
 #include <cstddef>

--- a/src/utilities/Logger.hpp
+++ b/src/utilities/Logger.hpp
@@ -41,8 +41,10 @@ enum class LogLevel {
     FATAL = 50
 };
 
+#define UEB_FALLBACK_LOGGING_ENABLED   1
+#define UEB_FALLBACK_LOG_LEVEL         LogLevel::INFO
 
-inline std::string utc_timestamp() {
+inline std::string ueb_utc_timestamp() {
     using clock = std::chrono::system_clock;
     auto now = clock::now();
     auto tt = clock::to_time_t(now);
@@ -61,14 +63,14 @@ inline std::string utc_timestamp() {
     return oss.str();
 }
 
-inline std::string_view rstrip_newline(std::string_view s) {
+inline std::string_view ueb_rstrip_newline(std::string_view s) {
     while (!s.empty() && (s.back() == '\n' || s.back() == '\r')) {
         s.remove_suffix(1);
     }
     return s;
 }
 
-inline const char* level_to_string(LogLevel level) {
+inline const char* ueb_level_to_string(LogLevel level) {
     switch (level) {
         case LogLevel::DEBUG:   return "DEBUG";
         case LogLevel::INFO:    return "INFO";
@@ -79,27 +81,31 @@ inline const char* level_to_string(LogLevel level) {
     }
 }
 
+inline bool IsLoggingEnabled() {
+    return UEB_FALLBACK_LOGGING_ENABLED;
+}
+
+inline LogLevel GetLogLevel() {
+    return UEB_FALLBACK_LOG_LEVEL;  // simple default
+}
+
 inline void Log(LogLevel level, std::string_view message) {
+
+    if (message.empty()) return;
+    if (!IsLoggingEnabled()) return;
+    if (level < GetLogLevel()) return;
+
     std::ostringstream oss;
 
-    message = rstrip_newline(message);
+    message = ueb_rstrip_newline(message);
 
-    oss << utc_timestamp() << " "
+    oss << ueb_utc_timestamp() << " "
         << UEB_MODULE_ID << " "
-        << level_to_string(level) << " "
+        << ueb_level_to_string(level) << " "
         << message << '\n';
 
     std::cout << oss.str() << std::flush;   
 }
-
-inline bool IsLoggingEnabled() {
-    return true;  // always enabled in fallback
-}
-
-inline LogLevel GetLogLevel() {
-    return LogLevel::INFO;  // simple default
-}
-
 
 inline void Log(std::string_view message, LogLevel level) {
     Log(level, message);
@@ -107,6 +113,8 @@ inline void Log(std::string_view message, LogLevel level) {
 
 inline void Log(LogLevel level, const char* fmt, ...) {
     if (!fmt) return;
+    if (!IsLoggingEnabled()) return;
+    if (level < GetLogLevel()) return;
 
     va_list args;
     va_start(args, fmt);

--- a/src/utilities/Logger.hpp
+++ b/src/utilities/Logger.hpp
@@ -1,6 +1,7 @@
 #ifndef UEB_LOGGER_HPP
 #define UEB_LOGGER_HPP
 
+#ifdef USE_EWTS
 #include "ewts/module_constants.hpp"
 #include "ewts/logger.hpp"
 #include "ewts/log_levels.hpp"
@@ -13,5 +14,87 @@ using ewts::EwtsInit;
 using ewts::LogLevel;
 
 inline constexpr const char* UEB_MODULE_ID = ewts::modules::EWTS_ID_UEB;
+
+#else
+// Log all messages to stdout
+#include <cstdarg>
+#include <cstddef>
+#include <cstdio>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+inline constexpr const char* UEB_MODULE_ID = "UEB_BMI";
+
+// Minimal LogLevel enum (match EWTS values if possible)
+enum class LogLevel {
+    NOTSET = 0,
+    DEBUG = 10,
+    INFO = 20,
+    WARNING = 30,
+    SEVERE = 40,
+    FATAL = 50
+};
+
+inline bool IsLoggingEnabled() {
+    return true;  // always enabled in fallback
+}
+
+inline LogLevel GetLogLevel() {
+    return LogLevel::INFO;  // simple default
+}
+
+inline const char* level_to_string(LogLevel level) {
+    switch (level) {
+        case LogLevel::DEBUG:   return "DEBUG";
+        case LogLevel::INFO:    return "INFO";
+        case LogLevel::WARNING: return "WARN";
+        case LogLevel::SEVERE:  return "ERROR";
+        case LogLevel::FATAL:   return "FATAL";
+        default:                return "LOG";
+    }
+}
+
+inline void Log(LogLevel level, std::string_view message) {
+    std::ostringstream oss;
+    oss << UEB_MODULE_ID << " "
+        << level_to_string(level) << " "
+        << message << '\n';
+
+    std::cout << oss.str() << std::flush;   
+}
+
+inline void Log(std::string_view message, LogLevel level) {
+    Log(level, message);
+}
+
+inline void Log(LogLevel level, const char* fmt, ...) {
+    if (!fmt) return;
+
+    va_list args;
+    va_start(args, fmt);
+
+    va_list args_copy;
+    va_copy(args_copy, args);
+    int len = std::vsnprintf(nullptr, 0, fmt, args_copy);
+    va_end(args_copy);
+
+    if (len < 0) {
+        va_end(args);
+        return;
+    }
+
+    std::string buffer(static_cast<std::size_t>(len) + 1, '\0');
+    std::vsnprintf(buffer.data(), buffer.size(), fmt, args);
+    va_end(args);
+
+    buffer.resize(static_cast<std::size_t>(len));
+
+    Log(level, buffer);
+}
+
+#define LOG(...) Log(__VA_ARGS__)
+#endif
 
 #endif /* UEB_LOGGER_HPP */


### PR DESCRIPTION
Exclude ewts when `UEB_USE_EWTS` preprocessor symbol is not defined. This symbol is set in the `CMakeFiles.txt` based on the `USE_EWTS` symbol.

## Additions

- Added check for `UEB_USE_EWTS`. When defined include the ewts library and initialize the ewts logger, otherwise fallback to stdout logging

## Removals

- Initializing the ewts logger when `USE_EWTS` is not defined. Log messages will be sent to stdout

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`